### PR TITLE
Use K8S api and get metrics from pods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM openjdk:11
 COPY target/telemetry-broker-1.0-SNAPSHOT.jar telemetry-broker-1.0.jar
 ENV IMPORT_DELAY=20000
 ENV PROMETHEUS_URL="http://localhost"
-ENTRYPOINT java -Dprometheus.base.url=$PROMETHEUS_URL -Dimport.task.fixedDelay.in.milliseconds=$IMPORT_DELAY -jar /telemetry-broker-1.0.jar
+ENV CH_HOST="http://localhost"
+ENTRYPOINT java -Dprometheus.base.url=$PROMETHEUS_URL -Dimport.task.fixedDelay.in.milliseconds=$IMPORT_DELAY -Dch.connection.string=$CH_HOST -jar /telemetry-broker-1.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,13 @@
   </repositories>
 
   <dependencies>
+
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java</artifactId>
+      <version>10.0.0</version>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>

--- a/resource-manifests/telemetry-broker.yaml
+++ b/resource-manifests/telemetry-broker.yaml
@@ -32,6 +32,8 @@ spec:
               value: telemetry-broker
             - name: PROMETHEUS_URL
               value: prometheus.istio-system.svc.cluster.local
+            - name: CH_HOST
+              value: 51.250.75.145
 
           ports:
             - containerPort: 8080

--- a/resource-manifests/telemetry-broker.yaml
+++ b/resource-manifests/telemetry-broker.yaml
@@ -22,7 +22,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: apollin/telemetry-broker:v2
+        - image: apollin/telemetry-broker:v3
           imagePullPolicy: Always
           name: telemetry-broker
           env:

--- a/resource-manifests/telemetry-broker.yaml
+++ b/resource-manifests/telemetry-broker.yaml
@@ -22,7 +22,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: apollin/telemetry-broker:v3
+        - image: apollin/telemetry-broker-sandbox:v4
           imagePullPolicy: Always
           name: telemetry-broker
           env:

--- a/src/main/java/ru/cshse/project/importer/MetricsImportTask.java
+++ b/src/main/java/ru/cshse/project/importer/MetricsImportTask.java
@@ -25,7 +25,7 @@ public class MetricsImportTask {
     public MetricsImportTask(
             @Value("${clickhouse.export.batch.size:50}") int batchSize,
             ClickHouseExportService exportService,
-            @Qualifier("prometheusMetricsProvider") MetricsProvider metricsProvider
+            @Qualifier("podsMetricProvider") MetricsProvider metricsProvider
     ) {
         this.batchSize = batchSize;
         this.exportService = exportService;

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PlainMetricsClient.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PlainMetricsClient.java
@@ -6,7 +6,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
-import reactor.core.publisher.Mono;
 
 /**
  * @author apollin

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PlainMetricsClient.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PlainMetricsClient.java
@@ -3,6 +3,7 @@ package ru.cshse.project.sources.kubernetes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -10,6 +11,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 /**
  * @author apollin
  */
+@Component
 public class PlainMetricsClient {
 
     private static final Logger logger = LoggerFactory.getLogger(PlainMetricsClient.class);

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PlainMetricsClient.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PlainMetricsClient.java
@@ -1,0 +1,42 @@
+package ru.cshse.project.sources.kubernetes;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author apollin
+ */
+public class PlainMetricsClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(PlainMetricsClient.class);
+
+    private static final int SIZE = 16 * 1024 * 1024;
+    private static final ExchangeStrategies STRATEGIES = ExchangeStrategies.builder()
+            .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(SIZE))
+            .build();
+    private static final int DEFAULT_PORT = 15020;
+    private static final String DEFAULT_ENDPOINT = "/stats/prometheus";
+
+    public String get(String ip) {
+        var localClient = WebClient.builder()
+                .baseUrl(UriComponentsBuilder
+                        .fromHttpUrl("http://" + ip)
+                        .path(DEFAULT_ENDPOINT)
+                        .port(DEFAULT_PORT)
+                        .build().toString()
+                )
+                .exchangeStrategies(STRATEGIES)
+                .build();
+        return localClient
+                .get()
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+}

--- a/src/main/java/ru/cshse/project/sources/kubernetes/Pod.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/Pod.java
@@ -1,0 +1,14 @@
+package ru.cshse.project.sources.kubernetes;
+
+import lombok.Value;
+
+/**
+ * @author apollin
+ */
+@Value
+public class Pod {
+    String ip;
+    String service;
+    String cluster;
+    String name;
+}

--- a/src/main/java/ru/cshse/project/sources/kubernetes/Pod.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/Pod.java
@@ -8,7 +8,6 @@ import lombok.Value;
 @Value
 public class Pod {
     String ip;
-    String service;
-    String cluster;
-    String name;
+    String appName;
+    String namespace;
 }

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PodsDiscoveryService.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PodsDiscoveryService.java
@@ -1,0 +1,51 @@
+package ru.cshse.project.sources.kubernetes;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Endpoints;
+import io.kubernetes.client.openapi.models.V1EndpointsList;
+import io.kubernetes.client.util.ClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author apollin
+ */
+public class PodsDiscoveryService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PodsDiscoveryService.class);
+
+    public static List<Pod> getAllPods() throws IOException, ApiException {
+        ApiClient client = ClientBuilder.cluster().build();
+        Configuration.setDefaultApiClient(client);
+
+        CoreV1Api api = new CoreV1Api();
+
+        List<Pod> pods = new ArrayList<>();
+        V1EndpointsList endpoints = api.listEndpointsForAllNamespaces(null, null, null, null, null, null, null, null, null);
+        for (V1Endpoints eps : endpoints.getItems()) {
+            var subsets = eps.getSubsets();
+            if (subsets == null) {
+                logger.warn("Subsets is null");
+                continue;
+            }
+            for (var subset : subsets) {
+                if (subset == null) {
+                    logger.warn("Subset in subsets {} is null", eps.getMetadata().getName());
+                    continue;
+                }
+                for (var ip: subset.getAddresses()) {
+                    logger.info("Endpoints set {}, namespace {}, address {}, ip {}", eps.getMetadata().getName(), eps.getMetadata().getNamespace(), ip.getHostname(), ip.getIp());
+                    pods.add(new Pod(ip.getIp(), eps.getMetadata().getName(), eps.getMetadata().getNamespace()));
+                }
+            }
+        }
+        return pods;
+    }
+}

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PodsMetricProvider.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PodsMetricProvider.java
@@ -1,0 +1,82 @@
+package ru.cshse.project.sources.kubernetes;
+
+import java.io.IOException;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Endpoints;
+import io.kubernetes.client.openapi.models.V1EndpointsList;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.util.ClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author apollin
+ */
+public class PodsMetricProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(PodsMetricProvider.class);
+
+    public static void getAllPods() throws IOException, ApiException {
+        ApiClient client = ClientBuilder.cluster().build();
+        Configuration.setDefaultApiClient(client);
+        final int size = 16 * 1024 * 1024;
+        final ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(size))
+                .build();
+        CoreV1Api api = new CoreV1Api();
+        V1EndpointsList endpoints = api.listEndpointsForAllNamespaces(null, null, null, null, null, null, null, null, null);
+        for (V1Endpoints eps : endpoints.getItems()) {
+            var subsets = eps.getSubsets();
+            if (subsets == null) {
+                logger.warn("Subsets is null");
+                continue;
+            }
+            for (var subset : subsets) {
+                if (subset == null) {
+                    logger.warn("Subset in subsets {} is null", eps.getMetadata().getName());
+                    continue;
+                }
+                for (var ip: subset.getAddresses()) {
+                    logger.info("Endpoints set {}, namespace {}, address {}, ip {}", eps.getMetadata().getName(), eps.getMetadata().getNamespace(), ip.getHostname(), ip.getIp());
+                    var localClient = WebClient.builder()
+                            .baseUrl(UriComponentsBuilder
+                                    .fromHttpUrl("http://" + ip.getIp())
+                                    .path("/stats/prometheus")
+                                    .port(15020
+                                    ).build().toString()
+                            )
+                            .exchangeStrategies(strategies)
+                            .build();
+                    try {
+                        var result = localClient
+                                .get()
+                                .accept(MediaType.APPLICATION_JSON)
+                                .retrieve()
+                                .bodyToMono(String.class)
+                                .block();
+                        logger.info("Got result : {}", result);
+                    } catch (Exception e) {
+                        logger.error("Got error while requesting metrics", e);
+                    }
+
+
+                }
+            }
+        }
+        V1PodList list =
+                api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null);
+        logger.info("About to get all pods");
+        for (V1Pod item : list.getItems()) {
+            logger.info("Got pod {}", item.getMetadata().getName());
+        }
+    }
+}

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PodsMetricProvider.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PodsMetricProvider.java
@@ -1,82 +1,118 @@
 package ru.cshse.project.sources.kubernetes;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.Configuration;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.models.V1Endpoints;
-import io.kubernetes.client.openapi.models.V1EndpointsList;
-import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodList;
-import io.kubernetes.client.util.ClientBuilder;
+import lombok.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.MediaType;
-import org.springframework.web.reactive.function.client.ExchangeStrategies;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriComponentsBuilder;
+import ru.cshse.project.models.PrometheusMetricDto;
+import ru.cshse.project.parsing.PrometheusMetricsParser;
+import ru.cshse.project.sources.MetricsProvider;
 
 /**
  * @author apollin
  */
-public class PodsMetricProvider {
+public class PodsMetricProvider implements MetricsProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(PodsMetricProvider.class);
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
 
-    public static void getAllPods() throws IOException, ApiException {
-        ApiClient client = ClientBuilder.cluster().build();
-        Configuration.setDefaultApiClient(client);
-        final int size = 16 * 1024 * 1024;
-        final ExchangeStrategies strategies = ExchangeStrategies.builder()
-                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(size))
-                .build();
-        CoreV1Api api = new CoreV1Api();
-        V1EndpointsList endpoints = api.listEndpointsForAllNamespaces(null, null, null, null, null, null, null, null, null);
-        for (V1Endpoints eps : endpoints.getItems()) {
-            var subsets = eps.getSubsets();
-            if (subsets == null) {
-                logger.warn("Subsets is null");
+    private final PodsRegistry registry;
+    private final PlainMetricsClient client;
+    private final int threadCount;
+
+    public PodsMetricProvider(PodsRegistry registry, PlainMetricsClient client, int threadCount) {
+        this.registry = registry;
+        this.client = client;
+        this.threadCount = threadCount;
+    }
+
+    @Override
+    public Stream<PrometheusMetricDto> get() {
+        var pods = registry.getAll();
+        logger.info("Will try to get metrics from {} pods", pods.size());
+        var executor = Executors.newFixedThreadPool(threadCount);
+        var futures = pods.stream()
+                .map(pod -> executor.submit(new Job(pod)))
+                .collect(Collectors.toList());
+
+        executor.shutdown();
+        try {
+            executor.awaitTermination(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            logger.error("Executor did not terminate in {}", TIMEOUT, e);
+        }
+        return futures.stream().flatMap(future -> {
+            try {
+                return Optional.of(future.get()).stream();
+            } catch (InterruptedException | ExecutionException e) {
+                logger.error("Failed to get form future", e);
+                return Stream.empty();
+            }
+        }).flatMap(PodsMetricProvider::map);
+    }
+
+    private static Stream<PrometheusMetricDto> map(JobResult jobResult) {
+        var plainStringResult = jobResult.getPlainString();
+        var reader = new BufferedReader(new StringReader(plainStringResult));
+        var state = PrometheusMetricsParser.start();
+        while (true) {
+            String line = null;
+            try {
+                line = reader.readLine();
+            } catch (IOException e) {
+                logger.error("Got IOException", e);
                 continue;
             }
-            for (var subset : subsets) {
-                if (subset == null) {
-                    logger.warn("Subset in subsets {} is null", eps.getMetadata().getName());
-                    continue;
-                }
-                for (var ip: subset.getAddresses()) {
-                    logger.info("Endpoints set {}, namespace {}, address {}, ip {}", eps.getMetadata().getName(), eps.getMetadata().getNamespace(), ip.getHostname(), ip.getIp());
-                    var localClient = WebClient.builder()
-                            .baseUrl(UriComponentsBuilder
-                                    .fromHttpUrl("http://" + ip.getIp())
-                                    .path("/stats/prometheus")
-                                    .port(15020
-                                    ).build().toString()
-                            )
-                            .exchangeStrategies(strategies)
-                            .build();
-                    try {
-                        var result = localClient
-                                .get()
-                                .accept(MediaType.APPLICATION_JSON)
-                                .retrieve()
-                                .bodyToMono(String.class)
-                                .block();
-                        logger.info("Got result : {}", result);
-                    } catch (Exception e) {
-                        logger.error("Got error while requesting metrics", e);
-                    }
-
-
-                }
+            if (line == null) {
+                break;
             }
+            PrometheusMetricsParser.read(line, state);
         }
-        V1PodList list =
-                api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null);
-        logger.info("About to get all pods");
-        for (V1Pod item : list.getItems()) {
-            logger.info("Got pod {}", item.getMetadata().getName());
+        PrometheusMetricsParser.finish(state);
+
+        return state.getProcessed().stream().map(metric -> enrich(metric, jobResult.getPod()));
+    }
+
+    private static PrometheusMetricDto enrich(PrometheusMetricDto metric, Pod pod) {
+        var labels = new HashMap<>(metric.getLabels());
+        labels.put("ip", pod.getIp());
+        labels.put("app", pod.getAppName());
+        labels.put("namespace", pod.getNamespace());
+        return metric.toBuilder().labels(labels).build();
+    }
+
+    private final class Job implements Callable<JobResult> {
+
+        private final Pod pod;
+
+        private Job(Pod pod) {
+            this.pod = pod;
         }
+
+        @Override
+        public JobResult call() {
+            return new JobResult(
+                    client.get(pod.getIp()),
+                    pod
+            );
+        }
+    }
+
+    @Value
+    private static class JobResult {
+        String plainString;
+        Pod pod;
     }
 }

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PodsRegistry.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PodsRegistry.java
@@ -1,13 +1,16 @@
 package ru.cshse.project.sources.kubernetes;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
 
 /**
  * @author apollin
  */
-
+@Component
 public class PodsRegistry {
     private final Map<String, Pod> registry;
 
@@ -20,6 +23,13 @@ public class PodsRegistry {
     }
 
     public Collection<Pod> getAll() {
-        return registry.values();
+        return List.copyOf(registry.values());
+    }
+
+    public synchronized void updateAll(List<Pod> allPods) {
+        registry.clear();
+        for (var pod : allPods) {
+            registry.put(pod.getIp(), pod);
+        }
     }
 }

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PodsRegistry.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PodsRegistry.java
@@ -18,18 +18,18 @@ public class PodsRegistry {
         this.registry = new ConcurrentHashMap<>();
     }
 
-    public synchronized void add(Pod pod) {
-        registry.put(pod.getIp(), pod);
-    }
-
     public Collection<Pod> getAll() {
-        return List.copyOf(registry.values());
+        synchronized (registry) {
+            return List.copyOf(registry.values());
+        }
     }
 
-    public synchronized void updateAll(List<Pod> allPods) {
-        registry.clear();
-        for (var pod : allPods) {
-            registry.put(pod.getIp(), pod);
+    public void updateAll(List<Pod> allPods) {
+        synchronized (registry) {
+            registry.clear();
+            for (var pod : allPods) {
+                registry.put(pod.getIp(), pod);
+            }
         }
     }
 }

--- a/src/main/java/ru/cshse/project/sources/kubernetes/PodsRegistry.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/PodsRegistry.java
@@ -1,0 +1,25 @@
+package ru.cshse.project.sources.kubernetes;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author apollin
+ */
+
+public class PodsRegistry {
+    private final Map<String, Pod> registry;
+
+    public PodsRegistry() {
+        this.registry = new ConcurrentHashMap<>();
+    }
+
+    public synchronized void add(Pod pod) {
+        registry.put(pod.getIp(), pod);
+    }
+
+    public Collection<Pod> getAll() {
+        return registry.values();
+    }
+}

--- a/src/main/java/ru/cshse/project/sources/kubernetes/ServiceDiscoveryTask.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/ServiceDiscoveryTask.java
@@ -1,0 +1,23 @@
+package ru.cshse.project.sources.kubernetes;
+
+import java.io.IOException;
+
+import io.kubernetes.client.openapi.ApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author apollin
+ */
+@Component
+public class ServiceDiscoveryTask {
+    private static final Logger logger = LoggerFactory.getLogger(ServiceDiscoveryTask.class);
+
+    @Scheduled(fixedDelayString = "${import.task.fixedDelay.in.milliseconds}")
+    public void run() throws IOException, ApiException {
+        logger.info("Running test pods metric collector task");
+        PodsMetricProvider.getAllPods();
+    }
+}

--- a/src/main/java/ru/cshse/project/sources/kubernetes/ServiceDiscoveryTask.java
+++ b/src/main/java/ru/cshse/project/sources/kubernetes/ServiceDiscoveryTask.java
@@ -24,7 +24,7 @@ public class ServiceDiscoveryTask {
         this.registry = registry;
     }
 
-    @Scheduled(fixedDelayString = "${import.task.fixedDelay.in.milliseconds}") // todo: add pwn property for delay
+    @Scheduled(fixedDelayString = "${discovery.task.fixedDelay.in.milliseconds}")
     public void run() throws IOException, ApiException {
         Instant start = Instant.now();
         logger.info("Starting update of endpoints for scraping");

--- a/src/main/java/ru/cshse/project/sources/pod_metrics.txt
+++ b/src/main/java/ru/cshse/project/sources/pod_metrics.txt
@@ -1,0 +1,229 @@
+# TYPE istio_agent_endpoint_no_pod gauge
+istio_agent_endpoint_no_pod 0
+# HELP istio_agent_go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE istio_agent_go_gc_duration_seconds summary
+istio_agent_go_gc_duration_seconds{quantile="0"} 4.0113e-05
+istio_agent_go_gc_duration_seconds{quantile="0.25"} 7.3543e-05
+istio_agent_go_gc_duration_seconds{quantile="0.5"} 0.000105155
+istio_agent_go_gc_duration_seconds{quantile="0.75"} 0.000127745
+istio_agent_go_gc_duration_seconds{quantile="1"} 0.023985335
+istio_agent_go_gc_duration_seconds_sum 0.049351133
+istio_agent_go_gc_duration_seconds_count 92
+# HELP istio_agent_go_goroutines Number of goroutines that currently exist.
+# TYPE istio_agent_go_goroutines gauge
+istio_agent_go_goroutines 61
+# HELP istio_agent_go_info Information about the Go environment.
+# TYPE istio_agent_go_info gauge
+istio_agent_go_info{version="go1.17.6"} 1
+# HELP istio_agent_go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE istio_agent_go_memstats_alloc_bytes gauge
+istio_agent_go_memstats_alloc_bytes 1.0500992e+07
+# HELP istio_agent_go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE istio_agent_go_memstats_alloc_bytes_total counter
+istio_agent_go_memstats_alloc_bytes_total 4.84048528e+08
+# HELP istio_agent_go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE istio_agent_go_memstats_buck_hash_sys_bytes gauge
+istio_agent_go_memstats_buck_hash_sys_bytes 1.49858e+06
+# HELP istio_agent_go_memstats_frees_total Total number of frees.
+# TYPE istio_agent_go_memstats_frees_total counter
+istio_agent_go_memstats_frees_total 2.55559e+06
+# HELP istio_agent_go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE istio_agent_go_memstats_gc_cpu_fraction gauge
+istio_agent_go_memstats_gc_cpu_fraction 1.211218683634264e-05
+# HELP istio_agent_go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE istio_agent_go_memstats_gc_sys_bytes gauge
+istio_agent_go_memstats_gc_sys_bytes 6.103576e+06
+# HELP istio_agent_go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE istio_agent_go_memstats_heap_alloc_bytes gauge
+istio_agent_go_memstats_heap_alloc_bytes 1.0500992e+07
+# HELP istio_agent_go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE istio_agent_go_memstats_heap_idle_bytes gauge
+istio_agent_go_memstats_heap_idle_bytes 7.159808e+06
+# HELP istio_agent_go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE istio_agent_go_memstats_heap_inuse_bytes gauge
+istio_agent_go_memstats_heap_inuse_bytes 1.253376e+07
+# HELP istio_agent_go_memstats_heap_objects Number of allocated objects.
+# TYPE istio_agent_go_memstats_heap_objects gauge
+istio_agent_go_memstats_heap_objects 47921
+# HELP istio_agent_go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE istio_agent_go_memstats_heap_released_bytes gauge
+istio_agent_go_memstats_heap_released_bytes 4.554752e+06
+# HELP istio_agent_go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE istio_agent_go_memstats_heap_sys_bytes gauge
+istio_agent_go_memstats_heap_sys_bytes 1.9693568e+07
+# HELP istio_agent_go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE istio_agent_go_memstats_last_gc_time_seconds gauge
+istio_agent_go_memstats_last_gc_time_seconds 1.6519222247765868e+09
+# HELP istio_agent_go_memstats_lookups_total Total number of pointer lookups.
+# TYPE istio_agent_go_memstats_lookups_total counter
+istio_agent_go_memstats_lookups_total 0
+# HELP istio_agent_go_memstats_mallocs_total Total number of mallocs.
+# TYPE istio_agent_go_memstats_mallocs_total counter
+istio_agent_go_memstats_mallocs_total 2.603511e+06
+# HELP istio_agent_go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE istio_agent_go_memstats_mcache_inuse_bytes gauge
+istio_agent_go_memstats_mcache_inuse_bytes 4800
+# HELP istio_agent_go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE istio_agent_go_memstats_mcache_sys_bytes gauge
+istio_agent_go_memstats_mcache_sys_bytes 16384
+# HELP istio_agent_go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE istio_agent_go_memstats_mspan_inuse_bytes gauge
+istio_agent_go_memstats_mspan_inuse_bytes 164288
+# HELP istio_agent_go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE istio_agent_go_memstats_mspan_sys_bytes gauge
+istio_agent_go_memstats_mspan_sys_bytes 196608
+# HELP istio_agent_go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE istio_agent_go_memstats_next_gc_bytes gauge
+istio_agent_go_memstats_next_gc_bytes 1.355456e+07
+# HELP istio_agent_go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE istio_agent_go_memstats_other_sys_bytes gauge
+istio_agent_go_memstats_other_sys_bytes 918556
+# HELP istio_agent_go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE istio_agent_go_memstats_stack_inuse_bytes gauge
+istio_agent_go_memstats_stack_inuse_bytes 1.277952e+06
+# HELP istio_agent_go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE istio_agent_go_memstats_stack_sys_bytes gauge
+istio_agent_go_memstats_stack_sys_bytes 1.277952e+06
+# HELP istio_agent_go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE istio_agent_go_memstats_sys_bytes gauge
+istio_agent_go_memstats_sys_bytes 2.9705224e+07
+# HELP istio_agent_go_threads Number of OS threads created.
+# TYPE istio_agent_go_threads gauge
+istio_agent_go_threads 12
+# HELP istio_agent_istiod_connection_terminations The total number of connection errors to Istiod
+# TYPE istio_agent_istiod_connection_terminations counter
+istio_agent_istiod_connection_terminations{type="cancelled"} 5
+# HELP istio_agent_num_failed_outgoing_requests Number of failed outgoing requests (e.g. to a token exchange server, CA, etc.)
+# TYPE istio_agent_num_failed_outgoing_requests counter
+istio_agent_num_failed_outgoing_requests{request_type="csr"} 7
+# HELP istio_agent_num_outgoing_requests Number of total outgoing requests (e.g. to a token exchange server, CA, etc.)
+# TYPE istio_agent_num_outgoing_requests counter
+istio_agent_num_outgoing_requests{request_type="csr"} 8
+# HELP istio_agent_num_outgoing_retries Number of outgoing retry requests (e.g. to a token exchange server, CA, etc.)
+# TYPE istio_agent_num_outgoing_retries counter
+istio_agent_num_outgoing_retries{request_type="csr"} 32
+# HELP istio_agent_outgoing_latency The latency of outgoing requests (e.g. to a token exchange server, CA, etc.) in milliseconds.
+# TYPE istio_agent_outgoing_latency counter
+istio_agent_outgoing_latency{request_type="csr"} 14009.346666
+# HELP istio_agent_pilot_conflict_inbound_listener Number of conflicting inbound listeners.
+# TYPE istio_agent_pilot_conflict_inbound_listener gauge
+istio_agent_pilot_conflict_inbound_listener 0
+# HELP istio_agent_pilot_conflict_outbound_listener_http_over_current_tcp Number of conflicting wildcard http listeners with current wildcard tcp listener.
+# TYPE istio_agent_pilot_conflict_outbound_listener_http_over_current_tcp gauge
+istio_agent_pilot_conflict_outbound_listener_http_over_current_tcp 0
+# HELP istio_agent_pilot_conflict_outbound_listener_tcp_over_current_http Number of conflicting wildcard tcp listeners with current wildcard http listener.
+# TYPE istio_agent_pilot_conflict_outbound_listener_tcp_over_current_http gauge
+istio_agent_pilot_conflict_outbound_listener_tcp_over_current_http 0
+# HELP istio_agent_pilot_conflict_outbound_listener_tcp_over_current_tcp Number of conflicting tcp listeners with current tcp listener.
+# TYPE istio_agent_pilot_conflict_outbound_listener_tcp_over_current_tcp gauge
+istio_agent_pilot_conflict_outbound_listener_tcp_over_current_tcp 0
+# HELP istio_agent_pilot_destrule_subsets Duplicate subsets across destination rules for same host
+# TYPE istio_agent_pilot_destrule_subsets gauge
+istio_agent_pilot_destrule_subsets 0
+# HELP istio_agent_pilot_duplicate_envoy_clusters Duplicate envoy clusters caused by service entries with same hostname
+# TYPE istio_agent_pilot_duplicate_envoy_clusters gauge
+istio_agent_pilot_duplicate_envoy_clusters 0
+# HELP istio_agent_pilot_eds_no_instances Number of clusters without instances.
+# TYPE istio_agent_pilot_eds_no_instances gauge
+istio_agent_pilot_eds_no_instances 0
+# HELP istio_agent_pilot_endpoint_not_ready Endpoint found in unready state.
+# TYPE istio_agent_pilot_endpoint_not_ready gauge
+istio_agent_pilot_endpoint_not_ready 0
+# HELP istio_agent_pilot_no_ip Pods not found in the endpoint table, possibly invalid.
+# TYPE istio_agent_pilot_no_ip gauge
+istio_agent_pilot_no_ip 0
+# HELP istio_agent_pilot_virt_services Total virtual services known to pilot.
+# TYPE istio_agent_pilot_virt_services gauge
+istio_agent_pilot_virt_services 0
+# HELP istio_agent_pilot_vservice_dup_domain Virtual services with dup domains.
+# TYPE istio_agent_pilot_vservice_dup_domain gauge
+istio_agent_pilot_vservice_dup_domain 0
+# HELP istio_agent_pilot_xds Number of endpoints connected to this pilot using XDS.
+# TYPE istio_agent_pilot_xds gauge
+istio_agent_pilot_xds{version="1.12.3"} 2
+# HELP istio_agent_pilot_xds_config_size_bytes Distribution of configuration sizes pushed to clients
+# TYPE istio_agent_pilot_xds_config_size_bytes histogram
+istio_agent_pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",le="1"} 0
+istio_agent_pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",le="10000"} 2
+istio_agent_pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",le="1e+06"} 2
+istio_agent_pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",le="4e+06"} 2
+istio_agent_pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",le="1e+07"} 2
+istio_agent_pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",le="4e+07"} 2
+istio_agent_pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",le="+Inf"} 2
+istio_agent_pilot_xds_config_size_bytes_sum{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"} 5140
+istio_agent_pilot_xds_config_size_bytes_count{type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"} 2
+# HELP istio_agent_pilot_xds_push_time Total time in seconds Pilot takes to push lds, rds, cds and eds.
+# TYPE istio_agent_pilot_xds_push_time histogram
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="0.01"} 2
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="0.1"} 2
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="1"} 2
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="3"} 2
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="5"} 2
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="10"} 2
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="20"} 2
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="30"} 2
+istio_agent_pilot_xds_push_time_bucket{type="sds",le="+Inf"} 2
+istio_agent_pilot_xds_push_time_sum{type="sds"} 0.001475044
+istio_agent_pilot_xds_push_time_count{type="sds"} 2
+# HELP istio_agent_pilot_xds_pushes Pilot build and send errors for lds, rds, cds and eds.
+# TYPE istio_agent_pilot_xds_pushes counter
+istio_agent_pilot_xds_pushes{type="sds"} 2
+# HELP istio_agent_pilot_xds_send_time Total time in seconds Pilot takes to send generated configuration.
+# TYPE istio_agent_pilot_xds_send_time histogram
+istio_agent_pilot_xds_send_time_bucket{le="0.01"} 2
+istio_agent_pilot_xds_send_time_bucket{le="0.1"} 2
+istio_agent_pilot_xds_send_time_bucket{le="1"} 2
+istio_agent_pilot_xds_send_time_bucket{le="3"} 2
+istio_agent_pilot_xds_send_time_bucket{le="5"} 2
+istio_agent_pilot_xds_send_time_bucket{le="10"} 2
+istio_agent_pilot_xds_send_time_bucket{le="20"} 2
+istio_agent_pilot_xds_send_time_bucket{le="30"} 2
+istio_agent_pilot_xds_send_time_bucket{le="+Inf"} 2
+istio_agent_pilot_xds_send_time_sum 2.8993e-05
+istio_agent_pilot_xds_send_time_count 2
+# TYPE envoy_cluster_upstream_cx_length_ms histogram
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="5"} 3
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="10"} 4
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="25"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="50"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="100"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="250"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="500"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="1000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="2500"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="5000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="10000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="30000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="60000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="300000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="600000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="1800000"} 8
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="3600000"} 12
+envoy_cluster_upstream_cx_length_ms_bucket{cluster_name="xds-grpc",le="+Inf"} 12
+envoy_cluster_upstream_cx_length_ms_sum{cluster_name="xds-grpc"} 9150073.6999999992549419403076172
+envoy_cluster_upstream_cx_length_ms_count{cluster_name="xds-grpc"} 12
+# TYPE envoy_server_initialization_time_ms histogram
+envoy_server_initialization_time_ms_bucket{le="0.5"} 0
+envoy_server_initialization_time_ms_bucket{le="1"} 0
+envoy_server_initialization_time_ms_bucket{le="5"} 0
+envoy_server_initialization_time_ms_bucket{le="10"} 0
+envoy_server_initialization_time_ms_bucket{le="25"} 0
+envoy_server_initialization_time_ms_bucket{le="50"} 0
+envoy_server_initialization_time_ms_bucket{le="100"} 0
+envoy_server_initialization_time_ms_bucket{le="250"} 0
+envoy_server_initialization_time_ms_bucket{le="500"} 0
+envoy_server_initialization_time_ms_bucket{le="1000"} 0
+envoy_server_initialization_time_ms_bucket{le="2500"} 0
+envoy_server_initialization_time_ms_bucket{le="5000"} 0
+envoy_server_initialization_time_ms_bucket{le="10000"} 0
+envoy_server_initialization_time_ms_bucket{le="30000"} 0
+envoy_server_initialization_time_ms_bucket{le="60000"} 1
+envoy_server_initialization_time_ms_bucket{le="300000"} 1
+envoy_server_initialization_time_ms_bucket{le="600000"} 1
+envoy_server_initialization_time_ms_bucket{le="1800000"} 1
+envoy_server_initialization_time_ms_bucket{le="3600000"} 1
+envoy_server_initialization_time_ms_bucket{le="+Inf"} 1
+envoy_server_initialization_time_ms_sum{} 37500
+envoy_server_initialization_time_ms_count{} 1

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ ch.password=
 prometheus.base.url=localhost
 prometheus.port.my=9090
 clickhouse.export.batch.size=100
+pods.metrics.collection.thread.count=4

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 import.task.fixedDelay.in.milliseconds=20000
 metadata.import.task.fixedDelay.in.milliseconds=10000
+discovery.task.fixedDelay.in.milliseconds=30000
 ch.connection.string=51.250.83.218
 ch.connection.port=8123
 ch.user=default

--- a/src/test/java/ru/cshse/project/sources/prometheus/PrometheusClientTest.java
+++ b/src/test/java/ru/cshse/project/sources/prometheus/PrometheusClientTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class PrometheusClientTest {
 
     @Test
-    //Disabled
+    @Disabled
     public void test() {
         var client = new PrometheusClient("localhost", "9090");
         var targetMetricsResponse = client.getTargetsMetadata();

--- a/telemetry-broker.iml
+++ b/telemetry-broker.iml
@@ -16,6 +16,39 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: io.kubernetes:client-java:10.0.0" level="project" />
+    <orderEntry type="library" name="Maven: io.prometheus:simpleclient:0.12.0" level="project" />
+    <orderEntry type="library" name="Maven: io.prometheus:simpleclient_tracer_otel:0.12.0" level="project" />
+    <orderEntry type="library" name="Maven: io.prometheus:simpleclient_tracer_common:0.12.0" level="project" />
+    <orderEntry type="library" name="Maven: io.prometheus:simpleclient_tracer_otel_agent:0.12.0" level="project" />
+    <orderEntry type="library" name="Maven: io.prometheus:simpleclient_httpserver:0.12.0" level="project" />
+    <orderEntry type="library" name="Maven: io.prometheus:simpleclient_common:0.12.0" level="project" />
+    <orderEntry type="library" name="Maven: io.kubernetes:client-java-api:10.0.0" level="project" />
+    <orderEntry type="library" name="Maven: io.sundr:builder-annotations:0.22.0" level="project" />
+    <orderEntry type="library" name="Maven: io.sundr:sundr-core:0.22.0" level="project" />
+    <orderEntry type="library" name="Maven: io.sundr:sundr-codegen:0.22.0" level="project" />
+    <orderEntry type="library" name="Maven: io.sundr:resourcecify-annotations:0.22.0" level="project" />
+    <orderEntry type="library" name="Maven: javax.annotation:javax.annotation-api:1.3.2" level="project" />
+    <orderEntry type="library" name="Maven: io.swagger:swagger-annotations:1.6.2" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okhttp3:okhttp:3.14.9" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okio:okio:1.17.2" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okhttp3:logging-interceptor:3.14.9" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.9" level="project" />
+    <orderEntry type="library" name="Maven: io.gsonfire:gson-fire:1.8.4" level="project" />
+    <orderEntry type="library" name="Maven: joda-time:joda-time:2.10.6" level="project" />
+    <orderEntry type="library" name="Maven: org.joda:joda-convert:2.2.1" level="project" />
+    <orderEntry type="library" name="Maven: io.kubernetes:client-java-proto:10.0.0" level="project" />
+    <orderEntry type="library" name="Maven: org.yaml:snakeyaml:1.29" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.15" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-compress:1.20" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.12.0" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.36" level="project" />
+    <orderEntry type="library" name="Maven: org.bouncycastle:bcprov-ext-jdk15on:1.66" level="project" />
+    <orderEntry type="library" name="Maven: org.bouncycastle:bcpkix-jdk15on:1.66" level="project" />
+    <orderEntry type="library" name="Maven: org.bouncycastle:bcprov-jdk15on:1.66" level="project" />
+    <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java:3.13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-collections4:4.4" level="project" />
+    <orderEntry type="library" name="Maven: org.bitbucket.b_c:jose4j:0.7.2" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter:2.6.6" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot:2.6.6" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-context:5.3.18" level="project" />
@@ -31,7 +64,6 @@
     <orderEntry type="library" name="Maven: jakarta.annotation:jakarta.annotation-api:1.3.5" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-core:5.3.18" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-jcl:5.3.18" level="project" />
-    <orderEntry type="library" name="Maven: org.yaml:snakeyaml:1.29" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-starter-test:2.6.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-test:2.6.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-test-autoconfigure:2.6.6" level="project" />
@@ -39,7 +71,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: net.minidev:json-smart:2.4.8" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: net.minidev:accessors-smart:2.4.8" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm:9.1" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.36" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: jakarta.xml.bind:jakarta.xml.bind-api:2.3.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: jakarta.activation:jakarta.activation-api:1.2.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.assertj:assertj-core:3.21.0" level="project" />

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,6 @@
+mvn package clean
+mvn package
+docker build . -t apollin/telemetry-broker-sandbox:v4
+docker push apollin/telemetry-broker-sandbox:v4
+kubectl delete -f  resource-manifests/telemetry-broker.yaml
+kubectl apply -f  resource-manifests/telemetry-broker.yaml

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,11 @@
+echo "Building package"
 mvn package clean
 mvn package
+echo "Building image"
 docker build . -t apollin/telemetry-broker-sandbox:v4
+echo "Pushing image"
 docker push apollin/telemetry-broker-sandbox:v4
-kubectl delete -f  resource-manifests/telemetry-broker.yaml
-kubectl apply -f  resource-manifests/telemetry-broker.yaml
+echo "delete current deployment"
+kubectl delete -f  resource-manifests/telemetry-broker.yaml -n istio-system
+echo "apply new deployment"
+kubectl apply -f resource-manifests/telemetry-broker.yaml -n istio-system


### PR DESCRIPTION
To avoid direct usage of prometheus we do scraping ourselves
- we get enspooints from k8s api in separate cron task
- in regular metrics export task we use new provider which parses plain metrics retrieved from pods. Basically, we reincarnated the first version of metrics provider (see DummyMetricsProvider)